### PR TITLE
Fix GH action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Scan comment
       id: scan
-      uses: actions/comment-email-address-alerts@v8
+      uses: seisvelas/comment-email-address-alerts@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sorry, no idea how `actions/comment-email-address-alerts@v8` ended up there, should be `seisvelas/comment-email-address-alerts@v8`. 

Copied this config into a repo of mine to make sure I didn't make other silly mistakes, it should definitely work now. No idea how those mistakes got there in the first place, sorry!